### PR TITLE
feat(auth): T28 lock AI chat to admin

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -184,7 +184,7 @@ Knowledge-first IT publishing platform. One canonical page → 3 views (article,
 | T25 | ✓ | wire form submit → `PATCH /api/account/password`, show success/error feedback | V28,V29,V31,I.api |
 | T26 | ✓ | add tests for password change API route | V28,V29,V30,V31 |
 | T27 | ✓ | admin-only safeguard — remove `editor` role; upgrade middleware to check `role === 'admin'` for `/editor/*`, `/settings`; add `requireAdmin()` guard to all write API routes (`/api/pages` POST/PUT/DELETE, publish, tags, assets, relations, `/api/ai/draft`, `/api/ai/rewrite`); hide editor/AI nav links for non-admin; update schema default role; add tests | V32,V33,V34,V35,V36,V37,V38,V39 |
-| T28 | . | lock AI chat to admin — add `requireAdmin()` to `/api/chat`; add `/ask` to middleware matcher; hide "Ask AI" nav link for non-admin; update tests | V35,V40,V39,I.api |
+| T28 | ✓ | lock AI chat to admin — add `requireAdmin()` to `/api/chat`; add `/ask` to middleware matcher; hide "Ask AI" nav link for non-admin; update tests | V35,V40,V39,I.api |
 
 ## §B — Bugs
 

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -135,7 +135,7 @@ describe('middleware config', () => {
     expect(config.matcher).toContain('/editor/:path*');
     expect(config.matcher).toContain('/admin/:path*');
     expect(config.matcher).toContain('/settings/:path*');
-    expect(config.matcher).toContain('/ask');
+    expect(config.matcher).toContain('/ask/:path*');
   });
 
   it('does not match public paths', () => {

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -40,6 +40,14 @@ describe('middleware', () => {
     expect(new URL(res.headers.get('location')!).pathname).toBe('/login');
   });
 
+  // §V.40: /ask requires admin — redirect to login when no session
+  it('redirects to /login when no valid session on /ask path', async () => {
+    mockGetToken.mockResolvedValue(null);
+    const res = await middleware(makeRequest('/ask'));
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get('location')!).pathname).toBe('/login');
+  });
+
   it('preserves callbackUrl in redirect', async () => {
     mockGetToken.mockResolvedValue(null);
     const res = await middleware(makeRequest('/editor/abc-123'));
@@ -71,6 +79,14 @@ describe('middleware', () => {
     expect(new URL(res.headers.get('location')!).pathname).toBe('/');
   });
 
+  // §V.40: non-admin token → redirect to / for /ask
+  it('redirects non-admin to / on /ask path', async () => {
+    mockGetToken.mockResolvedValue({ sub: 'user-1', role: 'editor' });
+    const res = await middleware(makeRequest('/ask'));
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get('location')!).pathname).toBe('/');
+  });
+
   // §V.36: token with no role → redirect to /
   it('redirects user with no role to / on /editor path', async () => {
     mockGetToken.mockResolvedValue({ sub: 'user-1' });
@@ -97,6 +113,13 @@ describe('middleware', () => {
     expect(res.headers.get('location')).toBeNull();
   });
 
+  // §V.40: admin token → pass through for /ask
+  it('passes through when admin token on /ask path', async () => {
+    mockGetToken.mockResolvedValue({ sub: 'user-1', role: 'admin' });
+    const res = await middleware(makeRequest('/ask'));
+    expect(res.headers.get('location')).toBeNull();
+  });
+
   it('uses AUTH_SECRET before NEXTAUTH_SECRET', async () => {
     process.env.AUTH_SECRET = 'auth-secret';
     mockGetToken.mockResolvedValue({ sub: 'user-1', role: 'admin' });
@@ -108,10 +131,11 @@ describe('middleware', () => {
 });
 
 describe('middleware config', () => {
-  it('matches /editor, /admin, and /settings paths', () => {
+  it('matches /editor, /admin, /settings, and /ask paths', () => {
     expect(config.matcher).toContain('/editor/:path*');
     expect(config.matcher).toContain('/admin/:path*');
     expect(config.matcher).toContain('/settings/:path*');
+    expect(config.matcher).toContain('/ask');
   });
 
   it('does not match public paths', () => {

--- a/src/app/api/chat/__tests__/chat-admin-guard.test.ts
+++ b/src/app/api/chat/__tests__/chat-admin-guard.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+const mockAuth = vi.fn();
+vi.mock('@/lib/auth', () => ({
+  auth: () => mockAuth(),
+  requireAdmin: async () => {
+    const session = await mockAuth();
+    if (!session?.user || session.user.role !== 'admin') return null;
+    return session;
+  },
+  unauthorizedResponse: () =>
+    NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+}));
+
+vi.mock('@/db', () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: 'conv-1' }]),
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock('@/db/schema', () => ({
+  conversations: {},
+  messages: {},
+}));
+
+vi.mock('@/lib/ai/find-chat-model', () => ({
+  chatWithFallback: vi.fn().mockResolvedValue({
+    stream: (async function* () {
+      yield { choices: [{ delta: { content: 'test' } }] };
+    })(),
+    provider: { id: 'p1' },
+    modelId: 'm1',
+  }),
+}));
+
+vi.mock('@/lib/rag/search', () => ({
+  hybridSearch: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/lib/rate-limiter', () => ({
+  checkRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock('@/lib/ai/usage-logger', () => ({
+  logAIUsage: vi.fn(),
+}));
+
+vi.mock('@/lib/validation', () => ({
+  chatSchema: {},
+  validateBody: vi.fn().mockReturnValue({
+    success: true,
+    data: { message: 'test', scopeType: 'site' },
+  }),
+}));
+
+vi.mock('@/lib/content-snippet', () => ({
+  contentSnippet: vi.fn().mockReturnValue('snippet'),
+}));
+
+// §V.35: AI chat requires admin role
+describe('Chat admin guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POST /api/chat returns 401 without session', async () => {
+    mockAuth.mockResolvedValue(null);
+    const { POST } = await import('../../chat/route');
+    const req = new NextRequest('http://localhost/api/chat', {
+      method: 'POST',
+      body: JSON.stringify({ message: 'test' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /api/chat returns 401 with non-admin role', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'u1', email: 'e@e.com', role: 'editor' },
+    });
+    const { POST } = await import('../../chat/route');
+    const req = new NextRequest('http://localhost/api/chat', {
+      method: 'POST',
+      body: JSON.stringify({ message: 'test' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /api/chat succeeds with admin role', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'u1', email: 'admin@e.com', role: 'admin' },
+    });
+    const { POST } = await import('../../chat/route');
+    const req = new NextRequest('http://localhost/api/chat', {
+      method: 'POST',
+      body: JSON.stringify({ message: 'test' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    // Should not be 401 — either 200 (streaming) or other non-auth error
+    expect(res.status).not.toBe(401);
+  });
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -31,18 +31,18 @@ Answer the user's question based ONLY on the provided context chunks. Follow the
 6. Never make up information not present in the context`;
 
 export async function POST(request: NextRequest) {
-  const rateCheck = checkRateLimit(request, 30, 60_000);
-  if (!rateCheck.allowed) {
-    return new NextResponse('Too Many Requests', {
-      status: 429,
-      headers: { 'Retry-After': String(rateCheck.retryAfter) },
-    });
-  }
-
   try {
-    // §V.35: AI features require admin role
+    // §V.35: AI features require admin role — check before rate limit
     const session = await requireAdmin();
     if (!session) return unauthorizedResponse();
+
+    const rateCheck = checkRateLimit(request, 30, 60_000);
+    if (!rateCheck.allowed) {
+      return new NextResponse('Too Many Requests', {
+        status: 429,
+        headers: { 'Retry-After': String(rateCheck.retryAfter) },
+      });
+    }
 
     const body = await request.json();
     const v = validateBody(chatSchema, body);

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -31,18 +31,19 @@ Answer the user's question based ONLY on the provided context chunks. Follow the
 6. Never make up information not present in the context`;
 
 export async function POST(request: NextRequest) {
+  // Rate limit first — protect auth path from DoS
+  const rateCheck = checkRateLimit(request, 30, 60_000);
+  if (!rateCheck.allowed) {
+    return new NextResponse('Too Many Requests', {
+      status: 429,
+      headers: { 'Retry-After': String(rateCheck.retryAfter) },
+    });
+  }
+
   try {
-    // §V.35: AI features require admin role — check before rate limit
+    // §V.35: AI features require admin role
     const session = await requireAdmin();
     if (!session) return unauthorizedResponse();
-
-    const rateCheck = checkRateLimit(request, 30, 60_000);
-    if (!rateCheck.allowed) {
-      return new NextResponse('Too Many Requests', {
-        status: 429,
-        headers: { 'Retry-After': String(rateCheck.retryAfter) },
-      });
-    }
 
     const body = await request.json();
     const v = validateBody(chatSchema, body);

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -7,7 +7,7 @@ import { hybridSearch } from '@/lib/rag/search';
 import { checkRateLimit } from '@/lib/rate-limiter';
 import { logAIUsage } from '@/lib/ai/usage-logger';
 import { chatSchema, validateBody } from '@/lib/validation';
-import { auth } from '@/lib/auth';
+import { requireAdmin, unauthorizedResponse } from '@/lib/auth';
 import { contentSnippet } from '@/lib/content-snippet';
 
 interface Citation {
@@ -31,10 +31,7 @@ Answer the user's question based ONLY on the provided context chunks. Follow the
 6. Never make up information not present in the context`;
 
 export async function POST(request: NextRequest) {
-  // Tighter rate limit for unauthenticated users (cost protection)
-  const session = await auth();
-  const limit = session ? 30 : 5;
-  const rateCheck = checkRateLimit(request, limit, 60_000);
+  const rateCheck = checkRateLimit(request, 30, 60_000);
   if (!rateCheck.allowed) {
     return new NextResponse('Too Many Requests', {
       status: 429,
@@ -43,6 +40,10 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    // §V.35: AI features require admin role
+    const session = await requireAdmin();
+    if (!session) return unauthorizedResponse();
+
     const body = await request.json();
     const v = validateBody(chatSchema, body);
     if (!v.success) return v.response;

--- a/src/components/top-nav.tsx
+++ b/src/components/top-nav.tsx
@@ -14,7 +14,6 @@ const NAV_LINKS = [
   { href: '/discover', label: 'Discover', icon: 'home' },
   { href: '/blog', label: 'Article', icon: 'book' },
   { href: '/cheatsheets', label: 'Cheatsheet', icon: 'list' },
-  { href: '/ask', label: 'Ask AI', icon: 'sparkles' },
 ];
 
 export function TopNav({ onSearchOpen }: TopNavProps) {
@@ -156,6 +155,34 @@ export function TopNav({ onSearchOpen }: TopNavProps) {
           </Link>
         );
       })}
+
+      {/* §V.39, §V.40: Ask AI — admin only */}
+      {isAdmin && (() => {
+        const active = isActive('/ask');
+        return (
+          <Link
+            href="/ask"
+            className="nav-link-desktop"
+            style={{
+              cursor: 'pointer',
+              color: active ? 'var(--amber)' : 'var(--tx-2)',
+              fontSize: 13.5,
+              padding: '4px 8px',
+              borderRadius: 5,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 5,
+              fontWeight: active ? 500 : 400,
+              background: active ? 'var(--amber-bg)' : 'none',
+              transition: 'all .15s',
+              textDecoration: 'none',
+            }}
+          >
+            <Icon name="sparkles" size={14} />
+            <span className="nav-label">Ask AI</span>
+          </Link>
+        );
+      })()}
 
       <div style={{ width: 1, height: 20, background: 'var(--bd-default)' }} />
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,8 +2,8 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 
-// §V.36, §V.37, §V.38: /editor/*, /admin/*, /settings require admin role
-const ADMIN_REQUIRED = ['/editor', '/admin', '/settings'];
+// §V.36, §V.37, §V.38, §V.40: /editor/*, /admin/*, /settings, /ask require admin role
+const ADMIN_REQUIRED = ['/editor', '/admin', '/settings', '/ask'];
 
 export async function middleware(request: NextRequest) {
   const token = await getToken({
@@ -32,5 +32,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/editor/:path*', '/admin/:path*', '/settings/:path*'],
+  matcher: ['/editor/:path*', '/admin/:path*', '/settings/:path*', '/ask'],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -32,5 +32,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/editor/:path*', '/admin/:path*', '/settings/:path*', '/ask'],
+  matcher: ['/editor/:path*', '/admin/:path*', '/settings/:path*', '/ask/:path*'],
 };


### PR DESCRIPTION
### **User description**
## Summary

- Add `requireAdmin()` guard to `/api/chat` route — non-admin gets 401 (§V.35)
- Add `/ask` to middleware matcher — unauthenticated → login, non-admin → `/` (§V.40)
- Hide "Ask AI" nav link for non-admin users in top-nav (§V.39)
- Add tests: 3 chat admin guard tests + 4 middleware `/ask` tests

## Test plan

- [x] `pnpm test` — 118 tests pass
- [x] `pnpm tsc --noEmit` — zero errors
- [ ] Manual: log in as admin → "Ask AI" visible, chat works
- [ ] Manual: log out → "Ask AI" hidden, `/ask` redirects to login
- [ ] Manual: non-admin user → "Ask AI" hidden, `/ask` redirects to `/`
- [ ] Manual: `curl -X POST /api/chat` without auth → 401


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Restrict AI chat to admins

- Protect `/ask` via middleware

- Hide Ask AI for non-admins

- Add guard and middleware tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  user["User request"] --> middleware["Middleware checks /ask"]
  middleware -- "no session" --> login["Redirect to /login"]
  middleware -- "non-admin" --> home["Redirect to /"]
  middleware -- "admin" --> ask["Allow Ask AI"]
  ask --> chat["/api/chat"]
  chat -- "requires admin" --> ai["AI chat response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware.test.ts</strong><dd><code>Add middleware tests for Ask admin access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/__tests__/middleware.test.ts

<ul><li>Adds <code>/ask</code> unauthenticated redirect coverage.<br> <li> Verifies non-admin <code>/ask</code> redirects home.<br> <li> Verifies admin <code>/ask</code> access passes through.<br> <li> Updates matcher expectations for <code>/ask</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/brainstack/pull/3/files#diff-414af89058b9ac4e632fbf4b1220e273c9e595f464d35521a19d2dbdf958e5b4">+25/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat-admin-guard.test.ts</strong><dd><code>Test admin guard on chat API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/chat/__tests__/chat-admin-guard.test.ts

<ul><li>Adds mocked chat route guard tests.<br> <li> Covers missing session returning <code>401</code>.<br> <li> Covers non-admin role returning <code>401</code>.<br> <li> Confirms admin role avoids auth rejection.</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/brainstack/pull/3/files#diff-3e6b4b37a25eaf2061a5181cf83eb5ccbe45737b8a6dd5b0c0998b24165ff58b">+118/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Require admin access for chat API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/chat/route.ts

<ul><li>Replaces <code>auth()</code> usage with <code>requireAdmin()</code>.<br> <li> Returns <code>unauthorizedResponse()</code> for non-admins.<br> <li> Applies fixed chat rate limit of <code>30</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/brainstack/pull/3/files#diff-a7bb5d29209ed018911d153136e25fad9cba4f3201714af7b35a7b4ef352c6d8">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>top-nav.tsx</strong><dd><code>Hide Ask AI navigation for non-admins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/top-nav.tsx

<ul><li>Removes <code>Ask AI</code> from public nav links.<br> <li> Renders <code>/ask</code> link only for <code>isAdmin</code>.<br> <li> Preserves active styling for admin Ask link.</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/brainstack/pull/3/files#diff-95799c11184f0eab002249f49042008b6a7161a9a1d58668d160b9028814d5e4">+28/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>middleware.ts</strong><dd><code>Protect Ask page with admin middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/middleware.ts

<ul><li>Adds <code>/ask</code> to admin-required paths.<br> <li> Adds <code>/ask</code> to middleware matcher config.<br> <li> Redirects unauthenticated and non-admin users consistently.</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/brainstack/pull/3/files#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SPEC.md</strong><dd><code>Mark AI chat admin lock complete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SPEC.md

<ul><li>Marks <code>T28</code> as completed.<br> <li> Documents admin lock completion for AI chat.</ul>


</details>


  </td>
  <td><a href="https://github.com/rendyuwu/brainstack/pull/3/files#diff-7426c9e3a694ca6015df5f98637912975f2edea23270203ee89a8bdeed246ee0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

