### PR TITLE
feat(ci): add Claude Code GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,34 @@
+name: Claude Code
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model enowxai/claude-opus-4.6 --max-turns 10"
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}


### PR DESCRIPTION
## Summary
- Add Claude Code Action workflow (`.github/workflows/claude.yml`)
- Triggers on `@claude` mentions in PR comments, issue comments, and issue bodies
- Uses custom API endpoint via `ANTHROPIC_BASE_URL` secret
- Model: `enowxai/claude-opus-4.6`

## Secrets required
- `ANTHROPIC_API_KEY` ✅
- `ANTHROPIC_BASE_URL` ✅

## Test plan
- [ ] Merge to master
- [ ] Open issue or PR comment with `@claude hello`
- [ ] Verify Actions tab shows workflow triggered
- [ ] Verify Claude responds