### PR TITLE
fix(ci): fix 3 bugs in Claude CI workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,6 +53,7 @@ jobs:
           curl -fsSL "https://raw.githubusercontent.com/rtk-ai/rtk/${RTK_SHA}/install.sh" | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/rtk" --version
+          mkdir -p "$HOME/.claude"
           "$HOME/.local/bin/rtk" init -g --auto-patch
 
       - name: Run Claude Code
@@ -62,12 +63,12 @@ jobs:
           github_token: ${{ github.token }}
 
           plugin_marketplaces: |
-            https://github.com/JuliusBrussee/caveman
-            https://github.com/JuliusBrussee/cavekit
+            https://github.com/JuliusBrussee/caveman.git
+            https://github.com/JuliusBrussee/cavekit.git
 
           plugins: |
             caveman@caveman
-            ck@cavekit
+            ck@cavekit-marketplace
 
           claude_args: "--model enowxai/claude-opus-4.6 --max-turns 100"
         env:


### PR DESCRIPTION
## Summary
- Add `mkdir -p "$HOME/.claude"` before `rtk init -g --auto-patch` — prevents ENOENT when `.claude/` dir doesn't exist in CI
- Add `.git` suffix to plugin marketplace URLs — required by `claude-code-action` plugin resolver
- Fix plugin name `ck@cavekit` → `ck@cavekit-marketplace` — matches actual marketplace package name

## Test plan
- [ ] Trigger workflow via `@claude` mention in an issue
- [ ] Verify rtk installs without error
- [ ] Verify caveman + cavekit plugins load correctly