### PR TITLE
fix(ci): remove rtk and reduce max-turns to 30

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,15 +47,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install rtk
-        run: |
-          RTK_SHA="4338f029ec43b69eb959748ec02cd7885200c264"
-          curl -fsSL "https://raw.githubusercontent.com/rtk-ai/rtk/${RTK_SHA}/install.sh" | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/rtk" --version
-          mkdir -p "$HOME/.claude"
-          "$HOME/.local/bin/rtk" init -g --auto-patch
-
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
@@ -70,6 +61,6 @@ jobs:
             caveman@caveman
             ck@cavekit-marketplace
 
-          claude_args: "--model enowxai/claude-opus-4.6 --max-turns 100"
+          claude_args: "--model enowxai/claude-opus-4.6 --max-turns 30"
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}


### PR DESCRIPTION
## Summary
- Remove RTK install step from Claude CI workflow — suspected cause of read-loop behavior (45k prompt / 73 completion tokens per turn)
- Reduce `--max-turns` from 100 to 30 to cap runaway token burn

## Test plan
- [ ] Trigger Claude via issue comment with simple task (e.g. amend §I in SPEC.md)
- [ ] Verify completion tokens are reasonable (not stuck at 73)
- [ ] Verify task completes within ~10 turns
- [ ] If loop persists → problem is proxy/model config, not RTK